### PR TITLE
make sure variable is initialized.

### DIFF
--- a/lib/File/Flock/Forking.pm
+++ b/lib/File/Flock/Forking.pm
@@ -10,8 +10,10 @@ use Config;
 die "Import File::Flock::Forking before importing File::Flock"
 	if defined $File::Flock::VERSION;
 
-if ((!$Config{d_flock} && ! $ENV{FLOCK_FORKING_USE} eq 'flock')
-	|| $ENV{FLOCK_FORKING_USE} eq 'subprocess') 
+my $flock_forking_use = $ENV{FLOCK_FORKING_USE} || '';
+
+if ((!$Config{d_flock} && ! $flock_forking_use eq 'flock')
+	|| $flock_forking_use eq 'subprocess')
 {
 	$File::Flock::Forking::SubprocessEnabled = 1;
 	require File::Flock::Subprocess;


### PR DESCRIPTION
fixes warnings

Use of uninitialized value $ENV{"FLOCK_FORKING_USE"} in string eq at lib/File/Flock/Forking.pm line 13.
