### PR TITLE
add some more logging to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ perl:
   - "5.12"
   - "5.10"
   - "5.8"
+
+install:
+    - cpanm --quiet --installdeps --notest . || { cat ~/.cpanm/build.log ; false ; }


### PR DESCRIPTION
This could be useful in the future in cpanm fails to install a dependency.
