### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,92 +1,91 @@
 Revision history for Perl module File::Flock
 
-+ 2013/09/11 version 2013.09
+2013.09 2013-09-11
 
-Resolve un-initialized variable $ready in Subprocess.pm
-Resolve un-initialized variable isues in Forking.pm
+    - Resolve un-initialized variable $ready in Subprocess.pm
+    - Resolve un-initialized variable isues in Forking.pm
 
-+ 2013/04/17 version 2013.08
+2013.08 2013-04-17
 
-Removed "my $_" instances that broke older perls.
+    - Removed "my $_" instances that broke older perls.
 
-+ 2013/04/09 version 2013.07
+2013.07 2013-04-09
 
-Require IO::Event version 0.812 to work around a FreeBSD issue.
+    - Require IO::Event version 0.812 to work around a FreeBSD issue.
 
-+ 2013/04/05 version 2013.06
+2013.06 2013-04-05
 
-Added File::Flock::Forking to auto-select between File::Flock and
-File::Flock::Subprocess.
+    - Added File::Flock::Forking to auto-select between File::Flock and
+      File::Flock::Subprocess.
 
-Added File::Flock::Subprocess for machines that don't propogate
-locks across fork().
+    - Added File::Flock::Subprocess for machines that don't propogate
+      locks across fork().
 
-POD is now after __END__ instead of __DATA__.  Oops!
+    - POD is now after __END__ instead of __DATA__.  Oops!
 
-+ 2008/03/27 version 2008.01
+2008.01 2008-03-27
 
-Joshua Kronengold, mneme at io dot com, sent in a patch
-to use IO::File instead of the $gensym hack.  Applied.
+    - Joshua Kronengold, mneme at io dot com, sent in a patch
+      to use IO::File instead of the $gensym hack.  Applied.
 
-Carl Fürstenber, azatoth at gmail dot com and others 
-requested that license terms be spelled out.  Done.
+    - Carl Fürstenber, azatoth at gmail dot com and others 
+      requested that license terms be spelled out.  Done.
 
-+ 2004/11/19
+104.111901 2004-11-19
 
-Bugfix in &unlock for if the lock file has been removed.
+    - Bugfix in &unlock for if the lock file has been removed.
 
-Bugfix by Vadim O. Ustiansky <ustiansk@sai.msu.ru>.
+    - Bugfix by Vadim O. Ustiansky <ustiansk@sai.msu.ru>.
 
-+ 2001/06/05
+101.060501 2001-06-05
 
-Added $av0debug variable to note locking attempts in $0
+    - Added $av0debug variable to note locking attempts in $0
 
-+ 2001/05/18
+    [2001-05-18]
 
-Added lock_rename to the EXPORT list.
+    - Added lock_rename to the EXPORT list.
 
-+ 2000/09/25
+100.092501 2000-09-25
 
-Added tests to make sure 'nonblocking' works
+    - Added tests to make sure 'nonblocking' works
 
-+ 1999/12/17
+99.121701 1999-12-17
 
-Added the lock_rename() function.
+    - Added the lock_rename() function.
 
-+ 1999/06/22
+99.062201 1999-06-22
 
-SunOS systems seem to fail with EWOULDBLOCK on locked files.
+    - SunOS systems seem to fail with EWOULDBLOCK on locked files.
 
-+ 1999/06/21
+    [1999-06-21]
 
-It appears that on some systems (HP-UX) a blocking call to flock()
-can fail with EACCES instead of EAGAIN.
+    - It appears that on some systems (HP-UX) a blocking call to flock()
+      can fail with EACCES instead of EAGAIN.
 
-+ 1999/06/15
+    [1999-06-15]
 
-Perl changes.  File::Flock must change to keep up.  A call to
-lock() had to be changed to &lock().  Why?
+    - Perl changes.  File::Flock must change to keep up.  A call to
+      lock() had to be changed to &lock().  Why?
 
-+ 1998/12/01
+98.120101 1998-12-01
 
-More fixes for Solaris.  
+    - More fixes for Solaris.  
 
-Modified the unlock() function so that it can be called as a reference.
+    - Modified the unlock() function so that it can be called as a reference.
 
-+ 1998/11/30
+98.113001 1998-11-30
 
-Fixed the object-style interface.  
+    - Fixed the object-style interface.  
 
-Attempt to fix a double-unlock bug that makes the Linux port unhappy
+    - Attempt to fix a double-unlock bug that makes the Linux port unhappy
 
-+ 1998/11/26	
+98.112801 1998-11-26	
 
-Chaged O_RDONLY to O_RDWR for all file opens because Solaris won't let
-you get an exclusive lock on a read-only file.  Crazy!  Change suggested
-by Lupe Christoph <lupe@alanya.m.isar.de>.  Thanks!
+    - Chaged O_RDONLY to O_RDWR for all file opens because Solaris won't let
+      you get an exclusive lock on a read-only file.  Crazy!  Change suggested
+      by Lupe Christoph <lupe@alanya.m.isar.de>.  Thanks!
 
-Rewrote the handling of the removal of files created just so that
-they could be locked.  Also tried to make sure that now file descriptors
-could get leaked.
-
+    - Rewrote the handling of the removal of files created just so that
+      they could be locked.  Also tried to make sure that now file descriptors
+      could get leaked.
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+Revision history for Perl module File::Flock
 
 + 2013/09/11 version 2013.09
 


### PR DESCRIPTION
Hi,

I've changed your changelog to confirm to the spec in CPAN::Changes::Spec:
- renamed from CHANGELOG to Changes
- reformatted dates and added version numbers (found from backpan)

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
